### PR TITLE
Add support for ByteString output

### DIFF
--- a/Text/Sass/Compilation.hs
+++ b/Text/Sass/Compilation.hs
@@ -27,6 +27,7 @@ module Text.Sass.Compilation
   ) where
 
 import qualified Bindings.Libsass    as Lib
+import           Data.ByteString     (ByteString, packCString)
 import           Control.Applicative ((<$>))
 import           Control.Monad       (forM, (>=>))
 import           Foreign
@@ -83,6 +84,13 @@ instance SassResult String where
     toSassResult ptr = withForeignPtr ptr $ \ctx -> do
         result <- Lib.sass_context_get_output_string ctx
         !result' <- peekCString result
+        return result'
+
+-- | Only compiled code (UTF-8 encoding).
+instance SassResult ByteString where
+    toSassResult ptr = withForeignPtr ptr $ \ctx -> do
+        result <- Lib.sass_context_get_output_string ctx
+        !result' <- packCString result
         return result'
 
 -- | Compiled code with includes and a source map.

--- a/hsass.cabal
+++ b/hsass.cabal
@@ -1,5 +1,5 @@
 name:                hsass
-version:             0.2.0
+version:             0.3.0
 license:             MIT
 license-file:        LICENSE
 author:              Jakub Fijałkowski <fiolek94@gmail.com>
@@ -46,12 +46,13 @@ library
     , Text.Sass.Values.Internal
     , Text.Sass.Utils
   build-depends:
-    base               >= 4.7 && < 5,
-    hlibsass           >= 0.1.1,
-    data-default-class,
-    filepath           >= 1.0,
-    mtl                >= 2.2,
-    monad-loops        >= 0.3
+      base               >= 4.7 && < 5
+    , hlibsass           >= 0.1.1
+    , bytestring         >= 0.10.6
+    , data-default-class
+    , filepath           >= 1.0
+    , mtl                >= 2.2
+    , monad-loops        >= 0.3
   hs-source-dirs:      .
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -63,6 +64,7 @@ test-suite test
   ghc-options:         -Wall
   build-depends:
       base               >= 4.7 && < 5
+    , bytestring         >= 0.10.6
     , hspec              >= 2.1.5
     , hspec-discover     >= 2.1.5
     , temporary          >= 1.1

--- a/test/Text/Sass/CompilationSpec.hs
+++ b/test/Text/Sass/CompilationSpec.hs
@@ -5,6 +5,7 @@ import           System.IO.Temp
 import           Test.Hspec
 import           Text.Sass
 
+import           Data.ByteString.Char8  (ByteString, pack)
 import           Data.Either            (isLeft, isRight)
 import           Data.Maybe             (isJust)
 import           Text.Sass.TestingUtils
@@ -28,6 +29,10 @@ compilationSpec = do
     it "should compile simple source" $
         compileString "foo { margin: 21px * 2; }" def `shouldReturn`
             Right "foo {\n  margin: 42px; }\n"
+
+    it "should compile simple source as a bytestring" $
+        compileString "foo { margin: 21px * 2; }" def `shouldReturn`
+            Right (pack "foo {\n  margin: 42px; }\n")
 
     it "should respect options" $ do
         let opts = def { sassOutputStyle = SassStyleCompressed }


### PR DESCRIPTION
The reason I picked `ByteString` rather than `Text` is because libsass always outputs in UTF8 format. Users will probably also be outputting in UTF8. `Text` uses UTF-16, though, as you probably know, so staying in ByteString probably saves a round trip in the majority of cases.
