### PR TITLE
Provide custom importers with the absolute path to the importing file

### DIFF
--- a/Text/Sass/Functions.hs
+++ b/Text/Sass/Functions.hs
@@ -8,6 +8,8 @@ module Text.Sass.Functions
   , SassImport (..)
   , SassImporterType
   , SassImporter (..)
+  , SassHeaderType
+  , SassHeader (..)
   , makeSourceImport
   , makePathImport
   ) where
@@ -40,20 +42,32 @@ data SassImport = SassImport {
     importSourceMap :: Maybe String    -- ^ Source map of the import.
 }
 
--- | Type of the function that acts like importer/header.
+-- | Type of the function that acts like an importer.
 --
--- You may return empty list in order to tell libsass to handle the import by
--- itself or not insert any header.
+-- You may return the empty list in order to tell libsass to handle the import by
+-- itself.
 type SassImporterType =
        String
-       -- ^ Path to the import that needs to be loaded or file that is being
-       -- processed when used as a header.
+       -- ^ Path to the import that needs to be loaded.
+    -> String
+       -- ^ Absolute path to the importing file.
     -> IO [SassImport] -- ^ Imports.
 
 -- | Description of the importer.
 data SassImporter = SassImporter {
     importerPriority :: Double           -- ^ Priority of the importer.
   , importerFunction :: SassImporterType -- ^ Main function.
+}
+
+-- | Type of the function that acts like a header.
+type SassHeaderType =
+       String -- ^ Absolute path to the file being processed.
+    -> IO [SassImport] -- ^ Imports.
+
+-- | Description of the header.
+data SassHeader = SassHeader {
+    headerPriority :: Double -- ^ Priority of the header.
+  , headerFunction :: SassHeaderType -- ^ Main function.
 }
 
 -- | 'makeSourceImport' @s@ is equivalent to 'SassImport'

--- a/Text/Sass/Functions/Internal.hs
+++ b/Text/Sass/Functions/Internal.hs
@@ -75,9 +75,14 @@ freeNativeFunctionList = loopCList freeNativeFunction
 
 -- | Wraps function of type 'SassImporterType'.
 wrapImporter :: SassImporterType -> Lib.SassImporterFnType
-wrapImporter fn url _ _ = peekCString url >>= fn >>= \case
-    [] -> return nullPtr
-    xs -> makeNativeImportList xs
+wrapImporter fn url _ compiler = do
+    lastImport <- Lib.sass_compiler_get_last_import compiler
+    absPath <- Lib.sass_import_get_abs_path lastImport >>= peekCString
+    url' <- peekCString url
+    importList <- fn url' absPath
+    case importList of
+        [] -> return nullPtr
+        xs -> makeNativeImportList xs
 
 -- | Converts 'SassImport' into native representation.
 makeNativeImport :: SassImport -> IO Lib.SassImportEntry

--- a/Text/Sass/Options.hs
+++ b/Text/Sass/Options.hs
@@ -51,7 +51,7 @@ data SassOptions = SassOptions {
     -- | List of user-supplied functions that provide "headers" for sass files.
     -- Header is injected at the beginning of a file which name is passed as
     -- the first argument of importer.
-  , sassHeaders           :: Maybe [SassImporter]
+  , sassHeaders           :: Maybe [SassHeader]
     -- | List of user-supplied functions that resolve @import directives.
   , sassImporters         :: Maybe [SassImporter]
 }

--- a/Text/Sass/Options/Internal.hs
+++ b/Text/Sass/Options/Internal.hs
@@ -15,6 +15,7 @@ import           Control.Applicative          ((<$>))
 import           Control.Monad                ((>=>))
 import           Foreign
 import           Foreign.C
+import           Text.Sass.Functions
 import           Text.Sass.Functions.Internal
 import           Text.Sass.Options
 import           Text.Sass.Utils
@@ -45,11 +46,15 @@ copyOptionsToNative opt ptr = do
     withOptionalCString (sassSourceMapRoot opt)
         (Lib.sass_option_set_source_map_root ptr)
     maybe (return ())
-        (makeNativeImporterList >=> Lib.sass_option_set_c_headers ptr)
+        (makeNativeImporterList . fmap fromHeader
+         >=> Lib.sass_option_set_c_headers ptr)
         (sassHeaders opt)
     maybe (return ())
         (makeNativeImporterList >=> Lib.sass_option_set_c_importers ptr)
         (sassImporters opt)
+    where
+      fromHeader (SassHeader p f) = SassImporter p (\filename _ -> f filename)
+
 
 -- | Copies 'sassFunctions' to native object, executes action, clears leftovers
 -- (see documentation of 'makeNativeFunction') and returns action result.

--- a/test/Text/Sass/CompilationSpec.hs
+++ b/test/Text/Sass/CompilationSpec.hs
@@ -13,8 +13,8 @@ import           Text.Sass.TestingUtils
 main :: IO ()
 main = hspec spec
 
-importerFunc :: String -> IO [SassImport]
-importerFunc _ = return [makeSourceImport "a { margin: 1px; }"]
+importerFunc :: String -> String -> IO [SassImport]
+importerFunc _ _ = return [makeSourceImport "a { margin: 1px; }"]
 
 importers :: [SassImporter]
 importers = [SassImporter 1 importerFunc]

--- a/test/Text/Sass/FunctionsSpec.hs
+++ b/test/Text/Sass/FunctionsSpec.hs
@@ -23,7 +23,7 @@ altInclContent :: String
 altInclContent = "b {\n  margin: 5px; }\n"
 
 headerFunction :: String -> IO [SassImport]
-headerFunction _ = return [makeSourceImport inclContent]
+headerFunction src = return [makeSourceImport $ src ++ "{\n  margin: 1px; }\n"]
 
 headers :: [SassHeader]
 headers = [SassHeader 1 headerFunction]
@@ -51,9 +51,18 @@ spec = do
             Right "a {\n  margin: 1px; }\n"
 
     it "should correctly inject header" $ do
-        let opts = def { sassHeaders = Just headers }
+        let opts = def { sassHeaders = Just headers, sassInputPath = Just "path" }
         compileString "a { margin : 1px; }" opts `shouldReturn`
-            Right (inclContent ++ "\na {\n  margin: 1px; }\n")
+            Right ("path {\n  margin: 1px; }\n\na {\n  margin: 1px; }\n")
+
+    it "should not apply header to imports" $ do
+        let opts = def {
+            sassHeaders = Just headers
+          , sassImporters = Just importers
+          , sassInputPath = Just "path"
+        }
+        compileString "@import '_imp';" opts `shouldReturn`
+            Right ("path {\n  margin: 1px; }\n\n" ++ inclContent)
 
     it "should call importers" $ do
         let opts = def { sassImporters = Just importers }

--- a/test/Text/Sass/FunctionsSpec.hs
+++ b/test/Text/Sass/FunctionsSpec.hs
@@ -1,7 +1,7 @@
 module Text.Sass.FunctionsSpec where
 
 import           Test.Hspec
-import           Text.Sass
+import           Text.Sass  hiding (headerFunction)
 
 fooFunction :: SassValue -> IO SassValue
 fooFunction _ = return $ SassNumber 1 "px"
@@ -25,12 +25,12 @@ altInclContent = "b {\n  margin: 5px; }\n"
 headerFunction :: String -> IO [SassImport]
 headerFunction _ = return [makeSourceImport inclContent]
 
-headers :: [SassImporter]
-headers = [SassImporter 1 headerFunction]
+headers :: [SassHeader]
+headers = [SassHeader 1 headerFunction]
 
-importFunction :: String -> IO [SassImport]
-importFunction "_imp" = return [makeSourceImport inclContent]
-importFunction _      = return [makeSourceImport altInclContent]
+importFunction :: String -> String -> IO [SassImport]
+importFunction "_imp" _ = return [makeSourceImport inclContent]
+importFunction _      _ = return [makeSourceImport altInclContent]
 
 importers :: [SassImporter]
 importers = [SassImporter 1 importFunction]

--- a/test/Text/Sass/TutorialSpec.hs
+++ b/test/Text/Sass/TutorialSpec.hs
@@ -27,11 +27,18 @@ header src = return [makeSourceImport $ "$file: " ++ src ++ ";"]
 headerSig :: SassHeader
 headerSig = SassHeader 1 header
 
+importer :: String -> String -> IO [SassImport]
+importer imp src = return
+    [makeSourceImport $ "/* imported " ++ imp ++ " into " ++ src ++ " */"]
+
+sassImporter :: Maybe [SassImporter]
+sassImporter = Just [SassImporter 1 importer]
+
 importer1 :: String -> String -> IO [SassImport]
-importer1 src _ = return [makeSourceImport $ "$file: " ++ src ++ "1;"]
+importer1 imp _ = return [makeSourceImport $ "$file: " ++ imp ++ "1;"]
 
 importer2 :: String -> String -> IO [SassImport]
-importer2 src _ = return [makeSourceImport $ "$file: " ++ src ++ "2;"]
+importer2 imp _ = return [makeSourceImport $ "$file: " ++ imp ++ "2;"]
 
 importerSigs :: [SassImporter]
 importerSigs = [SassImporter 0.5 importer1, SassImporter 1 importer2]
@@ -75,7 +82,11 @@ spec = do
             compileString "foo { prop: $file; }" opts `shouldReturn`
                 Right "foo {\n  prop: path; }\n"
 
-    describe "Importers" $
+    describe "Importers" $ do
+        it "should provide the importer with the correct arguments" $ do
+            let opts = def { sassImporters = sassImporter, sassInputPath = Just "file" }
+            compileString "@import \"relative/path\"" opts
+                `shouldReturn` Right "/* imported relative/path into file */\n"
         it "should inject import with higher priority" $ do
             let opts = def { sassImporters = Just importerSigs }
             compileString "@import \"file\";\nfoo { prop: $file; }" opts

--- a/test/Text/Sass/TutorialSpec.hs
+++ b/test/Text/Sass/TutorialSpec.hs
@@ -24,14 +24,14 @@ warnSig = SassFunction "@warn" . warn
 header :: String -> IO [SassImport]
 header src = return [makeSourceImport $ "$file: " ++ src ++ ";"]
 
-headerSig :: SassImporter
-headerSig = SassImporter 1 header
+headerSig :: SassHeader
+headerSig = SassHeader 1 header
 
-importer1 :: String -> IO [SassImport]
-importer1 src = return [makeSourceImport $ "$file: " ++ src ++ "1;"]
+importer1 :: String -> String -> IO [SassImport]
+importer1 src _ = return [makeSourceImport $ "$file: " ++ src ++ "1;"]
 
-importer2 :: String -> IO [SassImport]
-importer2 src = return [makeSourceImport $ "$file: " ++ src ++ "2;"]
+importer2 :: String -> String -> IO [SassImport]
+importer2 src _ = return [makeSourceImport $ "$file: " ++ src ++ "2;"]
 
 importerSigs :: [SassImporter]
 importerSigs = [SassImporter 0.5 importer1, SassImporter 1 importer2]


### PR DESCRIPTION
At the moment it's hard for a custom importer to resolve a relative import, since a `SassImporterType` only receives the relative path as input. This patch provides custom importers with the absolute path to the importing file.

I also added a new type for headers, since they only need to know the path to the importing file.