### PR TITLE
Add the option to strip encoding information from libsass' output

### DIFF
--- a/Text/Sass.hs
+++ b/Text/Sass.hs
@@ -70,6 +70,11 @@ import           Text.Sass.Values
 -- If you want access to the extended result, you have to use 'resultString',
 -- 'resultIncludes' and 'resultSourcemap' on the result to extract desirable
 -- information.
+--
+-- Note that if the compiled output contains non-ASCII characters, by default it
+-- will be prefixed with either a @\@charset@ rule indicating UTF-8 encoding or
+-- a byte-order mark (depending on the output style). If this is inconvenient,
+-- you can suppress it by enabling 'sassStripEncodingInfo'.
 
 -- $options
 -- 'SassOptions' wraps <http://libsass.org libsass> context options. It does not

--- a/Text/Sass/Options.hs
+++ b/Text/Sass/Options.hs
@@ -10,7 +10,9 @@ import qualified Bindings.Libsass    as Lib
 import           Data.Default.Class
 import           Text.Sass.Functions
 
--- | Describes options used by libsass during compilation.
+-- | Describes compilation options. With the exception of
+-- 'sassStripEncodingInfo', these correspond to the compilation options of
+-- libsass.
 data SassOptions = SassOptions {
     -- | Precision of fractional numbers.
     sassPrecision         :: Int
@@ -54,6 +56,9 @@ data SassOptions = SassOptions {
   , sassHeaders           :: Maybe [SassHeader]
     -- | List of user-supplied functions that resolve @import directives.
   , sassImporters         :: Maybe [SassImporter]
+    -- | Remove @\@charset \"UTF-8\";\\n@ or byte-order mark from CSS output,
+    -- if preset.
+  , sassStripEncodingInfo :: Bool
 }
 
 -- | The default 'SassOptions':
@@ -83,6 +88,7 @@ defaultSassOptions = SassOptions
   , sassFunctions         = Nothing
   , sassHeaders           = Nothing
   , sassImporters         = Nothing
+  , sassStripEncodingInfo = False
   }
 
 -- | 'def' = 'defaultSassOptions'

--- a/Text/Sass/Options.hs
+++ b/Text/Sass/Options.hs
@@ -57,7 +57,7 @@ data SassOptions = SassOptions {
     -- | List of user-supplied functions that resolve @import directives.
   , sassImporters         :: Maybe [SassImporter]
     -- | Remove @\@charset \"UTF-8\";\\n@ or byte-order mark from CSS output,
-    -- if preset.
+    -- if present.
   , sassStripEncodingInfo :: Bool
 }
 


### PR DESCRIPTION
Fixes #8.

I abandoned my initial approach of adding
```haskell
newtype StripEncodingInfo a = StripEncodingInfo a

instance SassResult (StripEncodingInfo String) where
    ...
```
since it felt too much like an abuse of typeclasses (and interacted awkwardly with `SassExtendedResult`). I thought it was more natural to add to `SassOptions`.

Possible alternatives:
- add a parameter to `compileString` and `compileFile`,
- or bake the paramter into new functions `compileStringStripped` etc.,
- or go with a typeclass based solution anyway.

I've marked this as WIP because I'm going to take a second look at the documentation. It would be nice to mention this issue in the tutorial, since it can lead to surprising problems.